### PR TITLE
Add props to ClerkProvider (plus some other minor changes)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,8 +2,9 @@ name: CI
 
 on:
   push:
-    tags:
-      - "v*.*.*"
+    # tags:
+    #   - "v*.*.*"
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["Publish"]
     types:
       - completed
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,7 @@ on:
     workflows: ["CI"]
     types:
       - completed
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,4 +6,4 @@ dist/
 site/
 .states/
 playwright_test_error.png
-.prettierignore
+.idea

--- a/README.md
+++ b/README.md
@@ -65,3 +65,8 @@ I use [Taskfile](https://taskfile.dev/) (similar to `makefile`) to make common t
 - `task run-docs` -- Run the docs locally
 - `task test` -- Run tests
 - `task bump-patch/minor/major` -- Bump the version (`patch` for a bug fix, `minor` for an added feature).
+
+
+## TODO:
+
+- How should the `condition` and `fallback` props be defined on `Protect`? They are supposed to be `Javascript` and `JSX` respectively, but are just `str` for now... Is `Javascript` `rx.Script`? And `JSX` `rx.Component`?

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Test Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/ci.yml/badge.svg?branch=v0.1.14)
+![Test Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/ci.yml/badge.svg?branch=v0.2.0)
 ![PyPi publish Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/publish.yml/badge.svg)
 ![Demo Deploy Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/deploy.yml/badge.svg)
 

--- a/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
+++ b/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
@@ -592,46 +592,56 @@ def user_profile_demo() -> rx.Component:
 
 
 def demo_header() -> rx.Component:
-    return rx.vstack(
-        rx.heading("Demos", size="6"),
-        rx.grid(
-            rx.vstack(
-                rx.text(
-                    "The demos below are using a development Clerk API key, so you can try out everything with fake credentials."
-                ),
-                rx.text(
-                    "To simply log in, you can use the email/password combination."
-                ),
-            ),
-            rx.card(
-                rx.vstack(
-                    rx.data_list.root(
-                        data_list_item(
-                            "username", rx.code("test+clerk_test@gmail.com")
-                        ),
-                        data_list_item("password", rx.code("test-clerk-password")),
-                    ),
-                    rx.hstack(
-                        clerk.signed_in(
-                            clerk.sign_out_button(
-                                rx.button("Sign out", data_testid="sign_out")
-                            )
-                        ),
-                        clerk.signed_out(
-                            rx.hstack(
-                                clerk.sign_in_button(
-                                    rx.button("Sign in", data_testid="sign_in")
-                                ),
-                                clerk.sign_up_button(
-                                    rx.button("Sign up", data_testid="sign_up")
-                                ),
-                            ),
-                        ),
-                    ),
-                ),
-            ),
-            columns=rx.breakpoints(initial="1", sm="2"),
+    demo_intro = rx.vstack(
+        rx.text(
+            "The demos below are using a development Clerk API key, so you can try out everything with fake credentials."
         ),
+        rx.text("To simply log in, you can use the email/password combination."),
+    )
+    clerk_user_info = rx.box(
+        clerk.clerk_loaded(
+            rx.cond(
+                clerk.ClerkState.is_signed_in,
+                rx.card(
+                    rx.hstack(
+                        rx.data_list.root(
+                            data_list_item(
+                                "Clerk user_id", rx.text(clerk.ClerkState.user_id)
+                            ),
+                            data_list_item("User button", clerk.user_button()),
+                        ),
+                    ),
+                ),
+                rx.text("Sign in to see user info."),
+            )
+        ),
+        clerk.clerk_loading(rx.spinner(size="3")),
+    )
+
+    test_user_and_pass = rx.card(
+        rx.vstack(
+            rx.data_list.root(
+                data_list_item("username", rx.code("test+clerk_test@gmail.com")),
+                data_list_item("password", rx.code("test-clerk-password")),
+            ),
+            rx.hstack(
+                clerk.signed_in(
+                    clerk.sign_out_button(rx.button("Sign out", data_testid="sign_out"))
+                ),
+                clerk.signed_out(
+                    rx.hstack(
+                        clerk.sign_in_button(
+                            rx.button("Sign in", data_testid="sign_in")
+                        ),
+                        clerk.sign_up_button(
+                            rx.button("Sign up", data_testid="sign_up")
+                        ),
+                    ),
+                ),
+            ),
+        ),
+    )
+    using_demo_instructions = rx.box(
         rx.text(
             "Or if you want test signing up, you can use any email with ",
             rx.code("+clerk_test"),
@@ -650,6 +660,18 @@ def demo_header() -> rx.Component:
                 "in the Clerk documentation.",
                 href="https://clerk.com/docs/testing/test-emails-and-phones",
             ),
+        ),
+    )
+
+    return rx.vstack(
+        rx.heading("Demos", size="6"),
+        rx.grid(
+            demo_intro,
+            clerk_user_info,
+            test_user_and_pass,
+            using_demo_instructions,
+            columns=rx.breakpoints(initial="1", sm="2"),
+            spacing="4",
         ),
     )
 
@@ -700,6 +722,13 @@ clerk.wrap_app(
     publishable_key=os.environ["CLERK_PUBLISHABLE_KEY"],
     secret_key=os.environ["CLERK_SECRET_KEY"],
     register_user_state=True,
+    # NOTE: Colors customizable via the `Appearance` object. (baseTheme is not yet implemented)
+    # appearance=Appearance(
+    #     variables=Variables(
+    #         color_primary="#111A27",
+    #         color_background="#C2F3FF",
+    #     ),
+    # ),
 )
 
 # NOTE: Use the `clerk.on_load` to ensure that the ClerkState is updated *before* any other on_load events are run.

--- a/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
+++ b/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
@@ -11,8 +11,11 @@ from reflex.event import EventType
 from rxconfig import config
 
 # Set up debug logging with a console handler
-logging.basicConfig(level=logging.DEBUG, handlers=[logging.StreamHandler()])
-logging.debug("Logging is set up.")
+logging.basicConfig(level=logging.INFO, handlers=[logging.StreamHandler()])
+# Just a very quick check to see which loggers are actually active in the console
+logging.debug("Logging DEBUG")
+logging.info("Logging INFO")
+logging.warning("Logging WARNING")
 
 
 load_dotenv()

--- a/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
+++ b/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
@@ -657,46 +657,51 @@ def demo_header() -> rx.Component:
 def index() -> rx.Component:
     clerk.register_on_auth_change_handler(State.do_something_on_log_in_or_out)
 
-    return clerk.clerk_provider(
-        rx.box(
-            rx.vstack(
-                rx.flex(
-                    demo_page_header_and_description(),
-                    getting_started(),
-                    spacing="7",
-                    direction=rx.breakpoints(initial="column", sm="row"),
-                ),
-                # rx.button("Dev reset", on_click=clerk.ClerkState.force_reset),
-                rx.divider(),
-                demo_header(),
-                rx.grid(
-                    current_clerk_state_values(),
-                    clerk_loaded_demo(),
-                    on_load_demo(),
-                    on_auth_change_demo(),
-                    user_info_demo(),
-                    links_to_demo_pages(),
-                    user_profile_demo(),
-                    columns=rx.breakpoints(initial="1", sm="2", md="3", xl="4"),
-                    spacing="4",
-                    align="stretch",
-                ),
-                align="center",
+    # Note: Using `clerk.wrap_app(...)` instead of `clerk.clerk_provider(...)` here.
+    return rx.box(
+        rx.vstack(
+            rx.flex(
+                demo_page_header_and_description(),
+                getting_started(),
                 spacing="7",
+                direction=rx.breakpoints(initial="column", sm="row"),
             ),
-            height="100vh",
-            max_width="100%",
-            overflow_y="auto",
-            padding="2em",
+            # rx.button("Dev reset", on_click=clerk.ClerkState.force_reset),
+            rx.divider(),
+            demo_header(),
+            rx.grid(
+                current_clerk_state_values(),
+                clerk_loaded_demo(),
+                on_load_demo(),
+                on_auth_change_demo(),
+                user_info_demo(),
+                links_to_demo_pages(),
+                user_profile_demo(),
+                columns=rx.breakpoints(initial="1", sm="2", md="3", xl="4"),
+                spacing="4",
+                align="stretch",
+            ),
+            align="center",
+            spacing="7",
         ),
-        publishable_key=os.environ["CLERK_PUBLISHABLE_KEY"],
-        register_user_state=True,
-        secret_key=os.environ.get("CLERK_SECRET_KEY"),
+        height="100vh",
+        max_width="100%",
+        overflow_y="auto",
+        padding="2em",
     )
 
 
 # Add state and page to the app.
 app = rx.App()
+
+# This wraps the entire app (all pages) with the ClerkProvider.
+clerk.wrap_app(
+    app,
+    publishable_key=os.environ["CLERK_PUBLISHABLE_KEY"],
+    secret_key=os.environ["CLERK_SECRET_KEY"],
+    register_user_state=True,
+)
+
 # NOTE: Use the `clerk.on_load` to ensure that the ClerkState is updated *before* any other on_load events are run.
 #  The `ClerkState` is updated by an event sent from the frontend that is not guaranteed to run before the reflex on_load events.
 app.add_page(

--- a/custom_components/reflex_clerk_api/__init__.py
+++ b/custom_components/reflex_clerk_api/__init__.py
@@ -5,6 +5,7 @@ from .clerk_provider import (
     clerk_provider,
     on_load,
     register_on_auth_change_handler,
+    wrap_app,
 )
 from .control_components import (
     clerk_loaded,
@@ -45,4 +46,5 @@ __all__ = [
     "signed_out",
     "user_button",
     "user_profile",
+    "wrap_app",
 ]

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -15,6 +15,8 @@ from reflex.utils.imports import ImportTypes
 
 from reflex_clerk_api.base import ClerkBase
 
+from .models import Appearance
+
 
 class ReflexClerkApiError(Exception):
     pass
@@ -330,8 +332,6 @@ function ClerkSessionSynchronizer({ children }) {
         ]
 
 
-Appearance = dict[str, Any]
-Localization = dict[str, Any]
 InitialState = dict[str, Any]
 # Should this be EventSpec instead?
 JSCallable = Callable
@@ -342,6 +342,11 @@ class ClerkProvider(ClerkBase):
 
     # The React component tag.
     tag = "ClerkProvider"
+
+    def add_imports(self) -> rx.ImportDict:
+        return {
+            "@clerk/themes": ["dark", "neobrutalism", "shadesOfPurple"],
+        }
 
     # The props of the React component.
     # Note: when Reflex compiles the component to Javascript,
@@ -381,20 +386,24 @@ class ClerkProvider(ClerkBase):
     clerk_js_version: str = ""
     """Define the npm version for @clerk/clerk-js."""
 
-    domain: str | Callable[[str], bool] = ""
+    # domain: str | JSCallable[[str], bool] = ""
+    domain: str = ""
     """Required if your application is a satellite application. Sets the domain."""
 
     dynamic: bool = False
     """(For Next.js only) Indicates whether Clerk should make dynamic auth data available."""
 
-    initial_state: InitialState | None = None
-    """Provide an initial state of the Clerk client during server-side rendering."""
+    # initial_state: InitialState | None = None
+    # """Provide an initial state of the Clerk client during server-side rendering."""
 
-    is_satellite: bool | Callable[[str], bool] = False
+    # is_satellite: bool | JSCallable[[str], bool] = False
+    is_satellite: bool = False
     """Whether the application is a satellite application."""
 
-    localization: Localization | None = None
-    """Optional object to localize your components. Will only affect Clerk components."""
+    # Not implemented
+    # localization: Localization | None = None
+    # See https://clerk.com/docs/customization/localization#clerk-localizations for more info.
+    # """Optional object to localize your components. Will only affect Clerk components."""
 
     nonce: str = ""
     """Nonce value passed to the @clerk/clerk-js script tag for CSP implementation."""
@@ -402,20 +411,21 @@ class ClerkProvider(ClerkBase):
     publishable_key: str = ""
     """The Clerk Publishable Key for your instance, found on the API keys page in the Clerk Dashboard."""
 
-    proxy_url: str | Callable[[str], str] = ""
+    # proxy_url: str | JSCallable[[str], str] = ""
+    proxy_url: str = ""
     """The URL of the proxy server to use for Clerk API requests."""
 
-    router_push: Callable[[str], None | Any] | None = None
+    router_push: JSCallable[[str], None | Any] | None = None
     """A function to push a new route into the history stack for navigation."""
 
-    router_replace: Callable[[str], None | Any] | None = None
+    router_replace: JSCallable[[str], None | Any] | None = None
     """A function to replace the current route in the history stack for navigation."""
 
-    sdk_metadata: dict[str, str] = {"name": "", "version": "", "environment": ""}
-    """Contains information about the SDK that the host application is using."""
+    # sdk_metadata: dict[str, str] = {"name": "", "version": "", "environment": ""}
+    # """Contains information about the SDK that the host application is using."""
 
-    select_initial_session: Callable[[Any], None | Any] | None = None
-    """Function to override the default behavior of using the last active session during client initialization."""
+    # select_initial_session: Callable[[Any], None | Any] | None = None
+    # """Function to override the default behavior of using the last active session during client initialization."""
 
     sign_in_fallback_redirect_url: str = "/"
     """The fallback URL to redirect to after the user signs in if there's no redirect_url in the path."""

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -458,3 +458,30 @@ def clerk_provider(
         publishable_key=publishable_key,
         **props,
     )
+
+
+def wrap_app(
+    app: rx.App,
+    publishable_key: str,
+    secret_key: str,
+    register_user_state: bool = False,
+) -> rx.App:
+    """Wraps the entire app with the ClerkProvider.
+
+    For multi-page apps where all pages require Clerk authentication components (including knowing if the user
+    is **not** signed in).
+
+    Args:
+        app: The Reflex app to wrap.
+        publishable_key: The Clerk Publishable Key for your instance.
+        secret_key: Your Clerk app's Secret Key.
+        register_user_state: Whether to register the ClerkUser state to automatically load user information on login.
+    """
+    # 1 makes this the first wrapper around the content
+    #  (0 would place it after, 100 would also wrap default reflex wrappers)
+    app.app_wraps[(1, "ClerkProvider")] = lambda _: clerk_provider(
+        publishable_key=publishable_key,
+        secret_key=secret_key,
+        register_user_state=register_user_state,
+    )
+    return app

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -3,7 +3,7 @@ import logging
 import os
 import time
 import uuid
-from typing import Any, ClassVar, TypeVar
+from typing import Any, Callable, ClassVar, TypeVar
 
 import authlib.jose.errors as jose_errors
 import clerk_backend_api
@@ -330,6 +330,13 @@ function ClerkSessionSynchronizer({ children }) {
         ]
 
 
+Appearance = dict[str, Any]
+Localization = dict[str, Any]
+InitialState = dict[str, Any]
+# Should this be EventSpec instead?
+JSCallable = Callable
+
+
 class ClerkProvider(ClerkBase):
     """ClerkProvider component."""
 
@@ -350,10 +357,101 @@ class ClerkProvider(ClerkBase):
     # trigger to what will be passed to the backend event handler function.
     # on_change: rx.EventHandler[lambda e: [e]]
 
-    publishable_key: str
-    """
-    The Clerk Publishable Key for your instance. This can be found on the API keys page in the Clerk Dashboard.
-    """
+    after_multi_session_single_sign_out_url: str = ""
+    """The URL to navigate to after a successful sign-out from multiple sessions."""
+
+    after_sign_out_url: str = ""
+    """The full URL or path to navigate to after a successful sign-out."""
+
+    allowed_redirect_origins: list[str | str] = []
+    """An optional list of domains to validate user-provided redirect URLs against."""
+
+    allowed_redirect_protocols: list[str] = []
+    """An optional list of protocols to validate user-provided redirect URLs against."""
+
+    appearance: Appearance | None = None
+    """Optional object to style your components. Will only affect Clerk components."""
+
+    clerk_js_url: str = ""
+    """Define the URL that @clerk/clerk-js should be hot-loaded from."""
+
+    clerk_js_variant: str | None = None
+    """If your web application only uses control components, set this to 'headless'."""
+
+    clerk_js_version: str = ""
+    """Define the npm version for @clerk/clerk-js."""
+
+    domain: str | Callable[[str], bool] = ""
+    """Required if your application is a satellite application. Sets the domain."""
+
+    dynamic: bool = False
+    """(For Next.js only) Indicates whether Clerk should make dynamic auth data available."""
+
+    initial_state: InitialState | None = None
+    """Provide an initial state of the Clerk client during server-side rendering."""
+
+    is_satellite: bool | Callable[[str], bool] = False
+    """Whether the application is a satellite application."""
+
+    localization: Localization | None = None
+    """Optional object to localize your components. Will only affect Clerk components."""
+
+    nonce: str = ""
+    """Nonce value passed to the @clerk/clerk-js script tag for CSP implementation."""
+
+    publishable_key: str = ""
+    """The Clerk Publishable Key for your instance, found on the API keys page in the Clerk Dashboard."""
+
+    proxy_url: str | Callable[[str], str] = ""
+    """The URL of the proxy server to use for Clerk API requests."""
+
+    router_push: Callable[[str], None | Any] | None = None
+    """A function to push a new route into the history stack for navigation."""
+
+    router_replace: Callable[[str], None | Any] | None = None
+    """A function to replace the current route in the history stack for navigation."""
+
+    sdk_metadata: dict[str, str] = {"name": "", "version": "", "environment": ""}
+    """Contains information about the SDK that the host application is using."""
+
+    select_initial_session: Callable[[Any], None | Any] | None = None
+    """Function to override the default behavior of using the last active session during client initialization."""
+
+    sign_in_fallback_redirect_url: str = "/"
+    """The fallback URL to redirect to after the user signs in if there's no redirect_url in the path."""
+
+    sign_up_fallback_redirect_url: str = "/"
+    """The fallback URL to redirect to after the user signs up if there's no redirect_url in the path."""
+
+    sign_in_force_redirect_url: str = ""
+    """URL to always redirect to after the user signs in."""
+
+    sign_up_force_redirect_url: str = ""
+    """URL to always redirect to after the user signs up."""
+
+    sign_in_url: str = ""
+    """URL used for any redirects that might happen, pointing to your primary application on the client-side."""
+
+    sign_up_url: str = ""
+    """URL used for any redirects that might happen, pointing to your primary application on the client-side."""
+
+    standard_browser: bool = True
+    """Indicates whether ClerkJS assumes cookies can be set (browser setup)."""
+
+    support_email: str = ""
+    """Optional support email for display in authentication screens."""
+
+    sync_host: str = ""
+    """URL of the web application that the Chrome Extension will sync the authentication state from."""
+
+    telemetry: bool | dict[str, bool] | None = None
+    """Controls whether Clerk will collect telemetry data."""
+
+    touch_session: bool = True
+    """Indicates whether the Clerk Frontend API touch endpoint is called during page focus to keep the last active session alive."""
+
+    waitlist_url: str = ""
+    """The full URL or path to the waitlist page."""
 
     @classmethod
     def create(cls, *children, **props) -> "ClerkProvider":

--- a/custom_components/reflex_clerk_api/control_components.py
+++ b/custom_components/reflex_clerk_api/control_components.py
@@ -1,5 +1,10 @@
 from reflex_clerk_api.base import ClerkBase
 
+Javascript = str
+JSX = str
+SignInInitialValues = dict[str, str]
+SignUpInitialValues = dict[str, str]
+
 
 class ClerkLoaded(ClerkBase):
     """Only renders children after authentication has been checked."""
@@ -16,17 +21,40 @@ class ClerkLoading(ClerkBase):
 class Protect(ClerkBase):
     tag = "Protect"
 
+    condition: Javascript | None = None
+    "Optional conditional logic that renders the children if it returns true"
+    fallback: JSX | None = None
+    "An optional snippet of JSX to show when a user doesn't have the role or permission to access the protected content."
+    permission: str | None = None
+    "Optional string corresponding to a Role's Permission in the format org:<resource>:<action>"
+    role: str | None = None
+    "Optional string corresponding to an Organization's Role in the format org:<role>"
+
 
 class RedirectToSignIn(ClerkBase):
     """Immediately redirects the user to the sign in page when rendered."""
 
     tag = "RedirectToSignIn"
 
+    signInFallbackRedirectUrl: str | None = None
+    "The fallback URL to redirect to after the user signs in, if there's no redirect_url in the path already. Defaults to /."
+    signInForceRedirectUrl: str | None = None
+    "If provided, this URL will always be redirected to after the user signs in."
+    initialValues: SignInInitialValues | None = None
+    "The values used to prefill the sign-in fields with."
+
 
 class RedirectToSignUp(ClerkBase):
     """Immediately redirects the user to the sign up page when rendered."""
 
     tag = "RedirectToSignUp"
+
+    signUpFallbackRedirectUrl: str | None = None
+    "The fallback URL to redirect to after the user signs up, if there's no redirect_url in the path already. Defaults to /."
+    signUpForceRedirectUrl: str | None = None
+    "If provided, this URL will always be redirected to after the user signs up."
+    initialValues: SignUpInitialValues | None = None
+    "The values used to prefill the sign-up fields with."
 
 
 class RedirectToUserProfile(ClerkBase):

--- a/custom_components/reflex_clerk_api/models.py
+++ b/custom_components/reflex_clerk_api/models.py
@@ -1,0 +1,99 @@
+from typing import Any, Literal
+
+from pydantic import BaseModel, Field
+
+LiteralBaseTheme = Literal["default", "dark", "neobrutalism", "shadesOfPurple"]
+
+
+class Layout(BaseModel):
+    animations: bool = True
+    """Whether to enable animations inside the components. Defaults to true."""
+
+    help_page_url: str = ""
+    """The URL to your help page."""
+
+    logo_image_url: str = ""
+    """The URL to your logo image."""
+
+    logo_link_url: str = ""
+    """Controls where the browser will redirect to after the user clicks the application logo."""
+
+    logo_placement: str = "inside"
+    """The placement of your logo. Defaults to 'inside'."""
+
+    privacy_page_url: str = ""
+    """The URL to your privacy page."""
+
+    shimmer: bool = True
+    """Enables the shimmer animation for avatars. Defaults to true."""
+
+    show_optional_fields: bool = True
+    """Whether to show optional fields on the sign in and sign up forms. Defaults to true."""
+
+    social_buttons_placement: str = "top"
+    """The placement of your social buttons. Defaults to 'top'."""
+
+    social_buttons_variant: str = "auto"
+    """The variant of your social buttons."""
+
+    terms_page_url: str = ""
+    """The URL to your terms page."""
+
+    unsafe_disable_development_mode_warnings: bool = False
+    """Whether development warnings show up in development mode."""
+
+
+class Variables(BaseModel):
+    color_primary: str = ""
+    color_danger: str = ""
+    color_success: str = ""
+    color_warning: str = ""
+    color_neutral: str = ""
+    color_text: str = ""
+    color_text_on_primary_background: str = ""
+    color_text_secondary: str = ""
+    color_background: str = ""
+    color_input_text: str = ""
+    color_input_background: str = ""
+    color_shimmer: str = ""
+    font_family: str = "inherit"
+    font_family_buttons: str = "inherit"
+    font_size: str = "0.8125rem"
+    font_weight: dict[str, int] = Field(
+        default_factory=lambda: {
+            "normal": 400,
+            "medium": 500,
+            "semibold": 600,
+            "bold": 700,
+        }
+    )
+    border_radius: str = "0.375rem"
+    spacing_unit: str = "1rem"
+
+
+class Captcha(BaseModel):
+    theme: str = "auto"
+    """The CAPTCHA widget theme. Defaults to auto."""
+
+    size: str = "normal"
+    """The CAPTCHA widget size. Defaults to normal."""
+
+    language: str = ""
+    """The CAPTCHA widget language/locale."""
+
+
+class Appearance(BaseModel):
+    base_theme: LiteralBaseTheme = "default"
+    """A theme used as the base theme for the components."""
+
+    layout: Layout | None = None
+    """Configuration options that affect the layout of the components."""
+
+    variables: Variables | None = None
+    """General theme overrides."""
+
+    elements: dict[str, Any] | None = None
+    """Fine-grained theme overrides."""
+
+    captcha: Captcha | None = None
+    """Configuration options that affect the appearance of the CAPTCHA widget."""

--- a/custom_components/reflex_clerk_api/models.py
+++ b/custom_components/reflex_clerk_api/models.py
@@ -1,11 +1,11 @@
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field
+from reflex.components.props import PropsBase
 
 LiteralBaseTheme = Literal["default", "dark", "neobrutalism", "shadesOfPurple"]
 
 
-class Layout(BaseModel):
+class Layout(PropsBase):
     animations: bool = True
     """Whether to enable animations inside the components. Defaults to true."""
 
@@ -43,7 +43,7 @@ class Layout(BaseModel):
     """Whether development warnings show up in development mode."""
 
 
-class Variables(BaseModel):
+class Variables(PropsBase):
     color_primary: str = ""
     color_danger: str = ""
     color_success: str = ""
@@ -59,19 +59,17 @@ class Variables(BaseModel):
     font_family: str = "inherit"
     font_family_buttons: str = "inherit"
     font_size: str = "0.8125rem"
-    font_weight: dict[str, int] = Field(
-        default_factory=lambda: {
-            "normal": 400,
-            "medium": 500,
-            "semibold": 600,
-            "bold": 700,
-        }
-    )
+    font_weight: dict[str, int] = {
+        "normal": 400,
+        "medium": 500,
+        "semibold": 600,
+        "bold": 700,
+    }
     border_radius: str = "0.375rem"
     spacing_unit: str = "1rem"
 
 
-class Captcha(BaseModel):
+class Captcha(PropsBase):
     theme: str = "auto"
     """The CAPTCHA widget theme. Defaults to auto."""
 
@@ -82,9 +80,10 @@ class Captcha(BaseModel):
     """The CAPTCHA widget language/locale."""
 
 
-class Appearance(BaseModel):
-    base_theme: LiteralBaseTheme = "default"
-    """A theme used as the base theme for the components."""
+class Appearance(PropsBase):
+    # TODO: This needs to reference the actual theme object, not a string -- don't know how to do that yet.
+    # base_theme: LiteralBaseTheme = "default"
+    # """A theme used as the base theme for the components."""
 
     layout: Layout | None = None
     """Configuration options that affect the layout of the components."""

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -88,6 +88,17 @@ The `publishable_key` and `secret_key` can be obtained from your [Clerk dashboar
 
     The `register_user_state` parameter is optional. Setting this to `True` enables the `clerk.ClerkUser` state which can be used to access or display basic user information.
 
+**alternatively**
+
+Wrap the entire app (all pages) via:
+
+```python
+
+clerk.wrap_app(app, publishable_key=...)
+```
+
+Taking the same arguments as `clerk.clerk_provider`.
+
 ### Environment Variables
 
 A good way to provide the keys is via environment variables (to avoid accidentally sharing them). You can do this by creating a `.env` file in the root of your project with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ venv = ".venv"
 
 [tool.ruff.lint]
 extend-select = ["I", "RUF"]
+ignore = ["RUF012"]
 
 [dependency-groups]
 dev = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ venvPath = "."
 venv = ".venv"
 
 [tool.ruff.lint]
-extend-select = ["I", "RUF"]
+extend-select = ["I", "RUF", "T20"]
 ignore = ["RUF012"]
 
 [dependency-groups]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reflex-clerk-api"
-version = "0.1.14"
+version = "0.2.0"
 description = "Reflex custom component wrapping @clerk/clerk-react and integrating the clerk-backend-api"
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ keywords = ["reflex","reflex-custom-components", "clerk", "clerk-backend-api"]
 dependencies = [
     "authlib>=1.5.1",
     "clerk-backend-api>=1.8.0",
-    "reflex>=0.7.0",
+    "reflex>=0.7.2",
 ]
 
 classifiers = [

--- a/scripts/bump-version.py
+++ b/scripts/bump-version.py
@@ -53,7 +53,7 @@ def main(part: LITERAL_PART, pyproject_path: Path, readme_path: Path) -> None:
     new_version = bump_version(current_version, part)
     update_toml_project_version(pyproject_path, new_version)
     update_readme_badge(readme_path, new_version)
-    print(f"Successfully bumped from {current_version} to {new_version}")
+    print(f"Successfully bumped from {current_version} to {new_version}")  # noqa: T201
 
 
 if __name__ == "__main__":

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -20,4 +20,4 @@ if __name__ == "__main__":
         raise ValueError("Usage: get-version.py <pyproject.toml-path>")
     path = Path(args[1])
     assert path.exists()
-    print(get_version_from_pyproject_toml(path))
+    print(get_version_from_pyproject_toml(path))  # noqa: T201

--- a/tests/test_demo.py
+++ b/tests/test_demo.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import uuid
 from pathlib import Path
@@ -37,7 +38,7 @@ def page(
     page.set_default_timeout(INTERACTION_TIMEOUT)
     yield page
     if request.session.testsfailed:
-        print("Test failed. Saving screenshot as playwright_test_error.png")
+        logging.error("Test failed. Saving screenshot as playwright_test_error.png")
         page.screenshot(path="playwright_test_error.png")
 
 
@@ -61,10 +62,10 @@ def create_test_user(clerk_client: Clerk) -> User:
             raise SetupError(
                 "Multiple test users found with same email... This should not happen."
             )
-        print("Test user already exists.")
+        logging.error("Test user already exists.")
         return existing[0]
 
-    print("Creating test user...")
+    logging.error("Creating test user...")
     res = clerk_client.users.create(
         request={
             "external_id": "ext-id-" + uuid.uuid4().hex[:5],

--- a/uv.lock
+++ b/uv.lock
@@ -1607,7 +1607,7 @@ requires-dist = [
     { name = "authlib", specifier = ">=1.5.1" },
     { name = "build", marker = "extra == 'dev'" },
     { name = "clerk-backend-api", specifier = ">=1.8.0" },
-    { name = "reflex", specifier = ">=0.7.0" },
+    { name = "reflex", specifier = ">=0.7.2" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
 provides-extras = ["dev"]

--- a/uv.lock
+++ b/uv.lock
@@ -1574,7 +1574,7 @@ wheels = [
 
 [[package]]
 name = "reflex-clerk-api"
-version = "0.1.14"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Mostly, this adds ClerkProvider props

Also a few other things
- fix minimum reflex version
- Add control_component props (mostly)
- Make workflows other than CI only run on main

Adds a `clerk.wrap_app(...)` helper for wrapping entire multi-page app in a single ClerkProvider.