### PR TITLE
Update for clerk backend 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Test Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/ci.yml/badge.svg?branch=v0.3.0)
+![Test Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/ci.yml/badge.svg?branch=v0.3.1)
 ![PyPi publish Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/publish.yml/badge.svg)
 ![Demo Deploy Status](https://github.com/TimChild/reflex-clerk-api/actions/workflows/deploy.yml/badge.svg)
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,9 @@ version: "3"
 
 dotenv: [".env"]
 
+vars:
+  INIT_PATH: "custom_components/reflex_clerk_api/__init__.py"
+
 tasks:
   install:
     cmds:
@@ -38,19 +41,19 @@ tasks:
   bump-patch:
     dir: "{{.TASKFILE_DIR}}"
     cmds:
-      - uv run scripts/bump-version.py patch pyproject.toml README.md
+      - uv run scripts/bump-version.py patch {{.INIT_PATH}} README.md
       - uv lock
 
   bump-minor:
     dir: "{{.TASKFILE_DIR}}"
     cmds:
-      - uv run scripts/bump-version.py minor pyproject.toml README.md
+      - uv run scripts/bump-version.py minor {{.INIT_PATH}} README.md
       - uv lock
 
   bump-major:
     dir: "{{.TASKFILE_DIR}}"
     cmds:
-      - uv run scripts/bump-version.py major pyproject.toml README.md
+      - uv run scripts/bump-version.py major {{.INIT_PATH}} README.md
       - uv lock
 
   publish:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,6 +23,7 @@ tasks:
       - task: lint
       - task: typecheck
     cmds:
+      - uv sync --dev
       - uv run playwright install chromium
       - uv run pytest
 

--- a/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
+++ b/clerk_api_demo/clerk_api_demo/clerk_api_demo.py
@@ -75,7 +75,11 @@ class State(rx.State):
 
 def demo_page_header_and_description() -> rx.Component:
     return rx.vstack(
-        rx.heading("reflex-clerk-api demo", size="9"),
+        rx.hstack(
+            rx.heading("reflex-clerk-api demo", size="9"),
+            rx.text(clerk.__version__),
+            align="baseline",
+        ),
         rx.heading(
             "Custom",
             rx.link(rx.code("reflex"), href="https://reflex.dev"),

--- a/custom_components/reflex_clerk_api/__init__.py
+++ b/custom_components/reflex_clerk_api/__init__.py
@@ -1,3 +1,5 @@
+__version__ = "0.3.1"
+
 from .authentication_components import sign_in, sign_up
 from .clerk_provider import (
     ClerkState,

--- a/custom_components/reflex_clerk_api/clerk_provider.py
+++ b/custom_components/reflex_clerk_api/clerk_provider.py
@@ -210,7 +210,7 @@ class ClerkState(rx.State):
         """
         if self._jwk_keys:
             return self._jwk_keys
-        jwks = await self.client.jwks.get_async()
+        jwks = await self.client.jwks.get_jwks_async()
         assert jwks is not None
         assert jwks.keys is not None
         keys = jwks.model_dump()["keys"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "reflex-clerk-api"
-version = "0.3.0"
 description = "Reflex custom component wrapping @clerk/clerk-react and integrating the clerk-backend-api"
 readme = "README.md"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.10"
 authors = [{ name = "Tim Child", email = "timjchild@gmail.com" }]
 keywords = ["reflex","reflex-custom-components", "clerk", "clerk-backend-api"]
+dynamic = ["version"]
 
 dependencies = [
     "authlib>=1.5.1,<2.0.0",
@@ -40,6 +40,9 @@ dev = ["build", "twine"]
 
 [tool.setuptools.packages.find]
 where = ["custom_components"]
+
+[tool.setuptools.dynamic]
+version = {attr = "reflex_clerk_api.__version__"}
 
 [tool.pytest.ini_options]
 # addopts = "--headed"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ keywords = ["reflex","reflex-custom-components", "clerk", "clerk-backend-api"]
 
 dependencies = [
     "authlib>=1.5.1,<2.0.0",
-    "clerk-backend-api>=1.8.0,<2.0.0",
+    "clerk-backend-api>=2.0.0,<3.0.0",
     "reflex>=0.7.2,<0.8.0",
 ]
 

--- a/scripts/get-version.py
+++ b/scripts/get-version.py
@@ -1,23 +1,22 @@
-"""Reads the version from the pyproject.toml file and returns to stdout."""
+"""Reads the version from the __init__.py file and returns to stdout."""
 
+import re
 import sys
 from pathlib import Path
 
-import tomlkit
 
-
-def get_version_from_pyproject_toml(file_path: Path) -> str:
-    with file_path.open("r") as file:
-        data = tomlkit.parse(file.read())
-    version = data["project"]["version"]  # pyright: ignore[reportIndexIssue]
-    assert isinstance(version, str)
-    return version
+def get_version_from_init(init_path: Path) -> str:
+    with init_path.open("r") as file:
+        data = file.readline()
+    match = re.search(r'^__version__ = "(.*)"', data)
+    assert match is not None
+    return match.group(1)
 
 
 if __name__ == "__main__":
     args = sys.argv
     if len(args) != 2:
-        raise ValueError("Usage: get-version.py <pyproject.toml-path>")
+        raise ValueError("Usage: get-version.py <package.__init__.py")
     path = Path(args[1])
     assert path.exists()
-    print(get_version_from_pyproject_toml(path))  # noqa: T201
+    print(get_version_from_init(path))  # noqa: T201

--- a/uv.lock
+++ b/uv.lock
@@ -255,7 +255,7 @@ wheels = [
 
 [[package]]
 name = "clerk-backend-api"
-version = "1.8.0"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -264,11 +264,11 @@ dependencies = [
     { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
-    { name = "typing-inspect" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/5c/0066df2ae201ddba438b2cf053e29af8d255e5adb80b69ece67b61021edc/clerk_backend_api-1.8.0.tar.gz", hash = "sha256:2b1498775c98c9f4e07e5ba06e98aea794577a8e1204b32329a71df064214175", size = 140612 }
+sdist = { url = "https://files.pythonhosted.org/packages/a7/65/c6240ac845b2ea29390a71de99fbdc5c9681d8d7c7c0f38489b4f7423994/clerk_backend_api-2.0.0.tar.gz", hash = "sha256:d1d77b7276502f3203d64a86b84c5e83576b67302845e89725b2effd4b399e55", size = 148801 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/86/2a/cd6e03c4df16823f7c6ca4dca109d8055e7190c59d122998e4e2d072b71f/clerk_backend_api-1.8.0-py3-none-any.whl", hash = "sha256:6da1a32fc8609354b5f3d0b46a032f01c67f17068fe004b91fa6e3f2733ecb37", size = 296117 },
+    { url = "https://files.pythonhosted.org/packages/c0/e4/d3bfbe9abe5af7c5627f325835259a07048106a2691fe83d51ff1ba4956e/clerk_backend_api-2.0.0-py3-none-any.whl", hash = "sha256:15d58fa167ba46e911840f3bd951c72d047e57da496d0dd06ccd0724e525c94b", size = 310685 },
 ]
 
 [[package]]
@@ -1023,15 +1023,6 @@ wheels = [
 ]
 
 [[package]]
-name = "mypy-extensions"
-version = "1.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/98/a4/1ab47638b92648243faf97a5aeb6ea83059cc3624972ab6b8d2316078d3f/mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782", size = 4433 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/e2/5d3f6ada4297caebe1a2add3b126fe800c96f56dbe5d1988a2cbe0b267aa/mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d", size = 4695 },
-]
-
-[[package]]
 name = "nh3"
 version = "0.2.21"
 source = { registry = "https://pypi.org/simple" }
@@ -1633,7 +1624,7 @@ dev = [
 requires-dist = [
     { name = "authlib", specifier = ">=1.5.1,<2.0.0" },
     { name = "build", marker = "extra == 'dev'" },
-    { name = "clerk-backend-api", specifier = ">=1.8.0,<2.0.0" },
+    { name = "clerk-backend-api", specifier = ">=2.0.0,<3.0.0" },
     { name = "reflex", specifier = ">=0.7.2,<0.8.0" },
     { name = "twine", marker = "extra == 'dev'" },
 ]
@@ -2010,19 +2001,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0e/3e/b00a62db91a83fff600de219b6ea9908e6918664899a2d85db222f4fbf19/typing_extensions-4.13.0.tar.gz", hash = "sha256:0a4ac55a5820789d87e297727d229866c9650f6521b64206413c4fbada24d95b", size = 106520 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e0/86/39b65d676ec5732de17b7e3c476e45bb80ec64eb50737a8dce1a4178aba1/typing_extensions-4.13.0-py3-none-any.whl", hash = "sha256:c8dd92cc0d6425a97c18fbb9d1954e5ff92c1ca881a309c45f06ebc0b79058e5", size = 45683 },
-]
-
-[[package]]
-name = "typing-inspect"
-version = "0.9.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "mypy-extensions" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825 }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827 },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1591,7 +1591,6 @@ wheels = [
 
 [[package]]
 name = "reflex-clerk-api"
-version = "0.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "authlib" },


### PR DESCRIPTION
Fix the breaking change introduced by `clerk-backend-api` going to `2.0.0`