### PR TITLE
ci: verify reflex 0.8.x compat in CI matrix

### DIFF
--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -59,7 +59,10 @@ jobs:
         shell: bash
         run: |
           uv venv --python ${{ matrix.python-versions }} --clear
-          uv pip install -e . "reflex>=0.8,<0.9" pytest pytest-pretty ruff pyright
+          # pytest-playwright + dotenv are needed for pyright to resolve imports
+          # in tests/test_demo.py and the demo app, even though we don't run them.
+          uv pip install -e . "reflex>=0.8,<0.9" \
+            pytest pytest-pretty pytest-playwright dotenv ruff pyright
 
       - name: Run Basic Checks
         if: inputs.check_type == 'basic' && matrix.reflex-version == 'locked'

--- a/.github/workflows/_reusable-ci.yml
+++ b/.github/workflows/_reusable-ci.yml
@@ -29,8 +29,17 @@ jobs:
     permissions:
       contents: read
     strategy:
+      fail-fast: false
       matrix:
         python-versions: ["3.11", "3.12", "3.13"]
+        reflex-version: ["locked"]
+        # Compat dimension: verify the package still works on the lower bound
+        # declared in pyproject.toml (`reflex>=0.8.0`). Bypasses uv.lock so a
+        # future bump that breaks 0.8.x will fail CI here instead of silently
+        # making the published package incompatible.
+        include:
+          - python-versions: "3.13"
+            reflex-version: "0.8"
     environment: ${{ inputs.environment || null }}
 
     steps:
@@ -45,13 +54,29 @@ jobs:
           python-version: ${{ matrix.python-versions }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Install with reflex 0.8.x (no lockfile)
+        if: matrix.reflex-version == '0.8'
+        shell: bash
+        run: |
+          uv venv --python ${{ matrix.python-versions }} --clear
+          uv pip install -e . "reflex>=0.8,<0.9" pytest pytest-pretty ruff pyright
+
       - name: Run Basic Checks
-        if: inputs.check_type == 'basic'
+        if: inputs.check_type == 'basic' && matrix.reflex-version == 'locked'
         uses: ./.github/actions/basic-checks
 
       - name: Run Full Checks
-        if: inputs.check_type == 'full'
+        if: inputs.check_type == 'full' && matrix.reflex-version == 'locked'
         uses: ./.github/actions/full-checks
         with:
           clerk-publishable-key: ${{ vars.CLERK_PUBLISHABLE_KEY }}
           clerk-secret-key: ${{ secrets.CLERK_SECRET_KEY }}
+
+      - name: Run Reflex 0.8.x Compat Checks
+        if: matrix.reflex-version == '0.8'
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          ruff check .
+          pyright
+          pytest tests/test_clerk_provider_unit.py


### PR DESCRIPTION
## Summary

Adds a CI matrix dimension that actually exercises the `reflex>=0.8.0` lower bound that `pyproject.toml` claims to support. After #26 bumped the lockfile to reflex 0.9.x, nothing was verifying that 0.8.x users could still install + import + run the package — a future bump could silently make published builds incompatible with the floor.

## Changes

- New `reflex-version` matrix variable on `_reusable-ci.yml`, defaulting to `"locked"` (the existing 3.11/3.12/3.13 jobs)
- One `include`: `python 3.13 + reflex 0.8` — bypasses `uv.lock`, resolves fresh against `reflex>=0.8,<0.9`, runs ruff + pyright + the unit test suite
- `fail-fast: false` so a 0.8 compat regression doesn't tank the locked-version jobs (or vice versa)
- Demo playwright tests stay on the locked version only — covering the demo on two reflex versions isn't worth the CI minutes given the demo's surface area

## Verification

Locally installed the package from main into a fresh venv with `reflex>=0.8,<0.9` (resolved to reflex 0.8.28.post1) and ran the unit tests — all passed.

## Test plan

- [ ] CI runs the new `ci (3.13, 0.8)` job and it passes
- [ ] Existing `ci (3.11/3.12/3.13, locked)` jobs still pass